### PR TITLE
Add search-rust-doc skill and subagent

### DIFF
--- a/.claude/agents/search-rust-doc.md
+++ b/.claude/agents/search-rust-doc.md
@@ -1,0 +1,84 @@
+---
+name: search-rust-doc
+description: Build and search Rust crate documentation on disk. Use when looking up types, traits, functions, or methods from a dependency. Pass the crate name and search term in the prompt.
+tools: Bash, Glob, Grep, Read
+model: haiku
+---
+
+Search Rust documentation for a specific crate and query. The caller will provide a **package** (crate name) and a **query** (type, trait, function, or method name to look up).
+
+## Process
+
+### 1. Build docs (only if not already present)
+
+Check whether docs exist before building to avoid wasted time:
+
+```bash
+ls target/doc/ 2>/dev/null | grep -E "^$(echo {package} | tr '-' '_')$"
+```
+
+If the directory is missing, build:
+
+```bash
+cargo doc -p {package} --no-deps 2>&1 | tail -5
+```
+
+### 2. Locate the crate doc directory
+
+Crate names with hyphens become underscores in the doc path:
+
+```bash
+CRATE_DIR=$(ls target/doc/ | grep -E "^$(echo {package} | tr '-' '_')$")
+echo "target/doc/$CRATE_DIR"
+```
+
+### 3. Search for the query — tiered approach
+
+**Tier 1 — filename match** (most precise): rustdoc names files after items.
+
+```bash
+find target/doc/$CRATE_DIR -name "*.html" | grep -i "{query}" | head -10
+```
+
+**Tier 2 — all.html listing** (broad item listing): `all.html` is a flat readable index of every public item in the crate.
+
+```bash
+grep -i "{query}" target/doc/$CRATE_DIR/all.html | head -20
+```
+
+**Tier 3 — HTML content search** (fallback): search inside HTML files for the query as a last resort:
+
+```bash
+grep -rl "{query}" target/doc/$CRATE_DIR/ --include="*.html" | head -5
+```
+
+### 4. Extract readable documentation
+
+For each relevant HTML file found, strip tags to extract human-readable text. Modern rustdoc HTML files are compact (typically under 50 lines), so read the whole file:
+
+```bash
+sed -E 's/<[^>]+>//g; s/&lt;/</g; s/&gt;/>/g; s/&amp;/\&/g; s/&#[0-9]+;//g' {file.html} \
+  | tr -s ' \t' ' ' \
+  | grep -v '^\s*$' \
+  | head -60
+```
+
+For method lookups within a struct/trait page, search for the method anchor within the file:
+
+```bash
+grep -EA 10 'id="(method|tymethod)\.{method_name}"' {file.html} \
+  | sed -E 's/<[^>]+>//g' \
+  | grep -v '^\s*$'
+```
+
+## Output
+
+Return **only**:
+1. The fully qualified item name (e.g., `difa::TagEncoder`)
+2. The item signature (struct fields, function signature, trait methods)
+3. The doc comment / description
+4. Relevant method signatures if the query was for a method
+
+Do NOT return: HTML tags, navigation boilerplate, build output, or entire file contents. Be concise — the caller needs actionable API information, not a full manual page.
+
+If nothing is found, say so clearly and suggest alternative search terms.

--- a/.claude/skills/search-rust-doc/SKILL.md
+++ b/.claude/skills/search-rust-doc/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: search-rust-doc
+description: Search Rust crate documentation for a type, trait, function, or method. Usage: /search-rust-doc {crate} {query}
+---
+
+# Search Rust Documentation
+
+Search the offline rustdoc output for a crate. Arguments (from `$ARGUMENTS`): the first word is the crate/package name, the rest is the search query.
+
+## Process
+
+Use the Task tool to invoke the `search-rust-doc` subagent with the prompt `Package: {crate}\nQuery: {query}`. Return the agent's findings directly to the user. If the user did not provide both a crate and a query, ask for the missing piece before invoking the agent.
+
+## Examples
+
+```
+/search-rust-doc difa TagEncoder
+/search-rust-doc ratatui Frame
+/search-rust-doc crossterm event::KeyCode
+/search-rust-doc ratatui widgets::Block title
+```


### PR DESCRIPTION
## Summary

- Adds a `search-rust-doc` haiku subagent that builds rustdoc for a given crate (`cargo doc -p {pkg} --no-deps`) and searches the generated HTML using a tiered strategy: filename match → `all.html` item index → full HTML content grep
- Adds a `/search-rust-doc {crate} {query}` user-invocable skill that delegates to the subagent, keeping verbose cargo output isolated from the main conversation context

## Test plan

- [ ] `/search-rust-doc difa TagEncoder` returns struct signature and doc comment
- [ ] `/search-rust-doc ratatui Frame` finds the Frame type
- [ ] Querying a crate whose docs are already built skips the `cargo doc` step
- [ ] Querying a non-existent item returns a clear "not found" message with alternative suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)