### PR TITLE
feat: phase 5.4 — remove q as navigation key, Esc only

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,20 +32,11 @@
 - **Export to Documents dir + log-type-aware filenames** (`feature/export-to-documents-dir`) — Done: ADIF exports written to `~/Documents/duklog/` (auto-created); filenames are log-type-specific: POTA → `{CALL}@{PARK}-{DATE}.adif`; General → `{CALL}-{DATE}.adif`; FD → `{CALL}-FD-{DATE}.adif`; WFD → `{CALL}-WFD-{DATE}.adif`; `/` in callsigns replaced with `_`; export path is editable on the export screen; `park_ref` made required on `PotaLog`; `DefaultFilename` trait added
 - **Phase 5.1 — Optional frequency for General and POTA logs** — Done
 - **Phase 5.3 — Log-type-aware recent QSO display** — Done: `draw_recent_qsos` branches on form type; General shows RST + freq; POTA shows RST + their_park (park takes priority over freq when both set); FD/WFD show exchange_rcvd + freq
+- **Phase 5.4 — `q`-key / `Esc` consistency audit** — Done: removed `q` as navigation key from Log Select, QSO List, and Help screens; `Esc` is the sole navigation/quit key everywhere
 
 ---
 
 ## Remaining Work
-
-### Phase 5.4 — `q`-key / `Esc` consistency audit
-
-**Priority: Low | Effort: Small | Depends on: —**
-
-**Why**: On screens with editable text fields, pressing `q` inserts the character `q` into the field rather than navigating away, which is surprising to users who expect `q` to quit. `Esc` is the correct and consistent key for cancelling/navigating back in editing contexts. Some screens currently bind both `q` and `Esc` for navigation; screens with free-text input should only use `Esc`.
-
-**Scope**: Audit all screens for `q`-as-navigation bindings. Remove `q` from any screen that has free-text input fields. Keep `q` on list/selection screens (Log Select, QSO List) where there is no text entry. Update `docs/user-guide.md` keybinding tables accordingly.
-
-**Files**: `src/tui/screens/*.rs`, `docs/user-guide.md`
 
 ### Phase 5.5 — ADIF native storage
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -29,7 +29,7 @@ cargo build --release
 
 ### Log Select
 
-The home screen. Shows all saved logs in a table with columns for Callsign, Date, Park, Grid, and QSO count.
+The home screen. Shows all saved logs in a table with columns for Callsign, Date, Type, Grid, and QSO count.
 
 | Key | Action |
 |---|---|
@@ -37,7 +37,7 @@ The home screen. Shows all saved logs in a table with columns for Callsign, Date
 | `Enter` | Open the selected log |
 | `n` | Create a new log |
 | `d` | Delete the selected log (asks for confirmation; `y` to confirm, `n`/`Esc` to cancel) |
-| `q` / `Esc` | Quit duklog |
+| `Esc` | Quit duklog |
 | `F1` | Show help |
 
 ### Log Create
@@ -157,7 +157,7 @@ A scrollable table of all QSOs in the current log. Columns: Time, Date, Call, Ba
 | `Home` / `End` | Jump to first / last row |
 | `Enter` | Edit the selected QSO |
 | `d` | Delete the selected QSO (prompts y/n) |
-| `q` / `Esc` | Back to QSO Entry |
+| `Esc` | Back to QSO Entry |
 | `F1` | Show help |
 
 Pressing `Enter` opens the selected QSO in the entry form for editing. Save with `Enter` or cancel with `Esc`.
@@ -194,12 +194,12 @@ The `~/Documents/duklog/` directory is created automatically if it does not exis
 
 ### Help
 
-Press `F1` from any screen to open context-sensitive help. The title shows which screen you are on, and only that screen's keybindings are shown. Pressing `q` or `Esc` returns you to the screen you came from.
+Press `F1` from any screen to open context-sensitive help. The title shows which screen you are on, and only that screen's keybindings are shown. Pressing `Esc` returns you to the screen you came from.
 
 | Key | Action |
 |---|---|
 | `Up` / `Down` | Scroll |
-| `q` / `Esc` | Return to previous screen |
+| `Esc` | Return to previous screen |
 
 ## Data Storage
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -488,10 +488,11 @@ mod tests {
         use super::*;
 
         #[test]
-        fn q_on_log_select_quits() {
+        fn q_on_log_select_is_ignored() {
             let (_dir, mut app) = make_app();
             app.handle_key(press(KeyCode::Char('q')));
-            assert!(app.should_quit());
+            assert!(!app.should_quit());
+            assert_eq!(app.screen(), Screen::LogSelect);
         }
 
         #[test]
@@ -510,13 +511,13 @@ mod tests {
         }
 
         #[test]
-        fn q_on_help_navigates_to_log_select() {
+        fn q_on_help_is_ignored() {
             let (_dir, mut app) = make_app();
             app.handle_key(press(KeyCode::F(1)));
             assert_eq!(app.screen(), Screen::Help);
 
             app.handle_key(press(KeyCode::Char('q')));
-            assert_eq!(app.screen(), Screen::LogSelect);
+            assert_eq!(app.screen(), Screen::Help);
             assert!(!app.should_quit());
         }
 
@@ -538,13 +539,13 @@ mod tests {
         }
 
         #[test]
-        fn q_on_help_returns_to_origin_screen() {
+        fn q_on_help_does_not_return_to_origin_screen() {
             let (_dir, mut app) = make_app();
             app.screen = Screen::QsoEntry;
             app.handle_key(press(KeyCode::F(1)));
             assert_eq!(app.screen(), Screen::Help);
             app.handle_key(press(KeyCode::Char('q')));
-            assert_eq!(app.screen(), Screen::QsoEntry);
+            assert_eq!(app.screen(), Screen::Help);
         }
 
         #[test]
@@ -569,7 +570,7 @@ mod tests {
             app.apply_action(Action::Navigate(Screen::Help));
             assert_eq!(app.screen(), Screen::Help);
 
-            app.handle_key(press(KeyCode::Char('q')));
+            app.handle_key(press(KeyCode::Esc));
             assert_eq!(app.screen(), Screen::QsoEntry);
         }
 
@@ -636,11 +637,11 @@ mod tests {
         }
 
         #[test]
-        fn q_on_qso_list_navigates_to_qso_entry() {
+        fn q_on_qso_list_is_ignored() {
             let (_dir, mut app) = make_app();
             app.screen = Screen::QsoList;
             app.handle_key(press(KeyCode::Char('q')));
-            assert_eq!(app.screen(), Screen::QsoEntry);
+            assert_eq!(app.screen(), Screen::QsoList);
             assert!(!app.should_quit());
         }
 
@@ -675,7 +676,7 @@ mod tests {
         use super::*;
 
         #[test]
-        fn n_q_and_esc_work_on_log_select_after_creating_first_log() {
+        fn n_and_esc_work_on_log_select_after_creating_first_log() {
             let (_dir, mut app) = make_app();
             assert_eq!(app.screen(), Screen::LogSelect);
 
@@ -702,11 +703,11 @@ mod tests {
             app.handle_key(press(KeyCode::Esc));
             assert_eq!(app.screen(), Screen::LogSelect);
 
-            // 'q' must quit
-            app.handle_key(press(KeyCode::Char('q')));
+            // Esc must quit
+            app.handle_key(press(KeyCode::Esc));
             assert!(
                 app.should_quit(),
-                "'q' should quit from LogSelect after first log created"
+                "'Esc' should quit from LogSelect after first log created"
             );
         }
     }
@@ -1511,12 +1512,12 @@ mod tests {
         }
 
         #[test]
-        fn q_on_qso_list_returns_to_qso_entry() {
+        fn q_on_qso_list_is_ignored() {
             let (_dir, mut app) = make_app_with_log();
             app.handle_key(alt_press(KeyCode::Char('e')));
             assert_eq!(app.screen(), Screen::QsoList);
             app.handle_key(press(KeyCode::Char('q')));
-            assert_eq!(app.screen(), Screen::QsoEntry);
+            assert_eq!(app.screen(), Screen::QsoList);
         }
 
         #[test]

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -15,7 +15,7 @@ static LOG_SELECT_KEYS: &[(&str, &str)] = &[
     ("Enter", "open log"),
     ("n", "new log"),
     ("d", "delete log (y/n to confirm)"),
-    ("q / Esc", "quit"),
+    ("Esc", "quit"),
     ("F1", "help"),
 ];
 
@@ -44,17 +44,14 @@ static QSO_LIST_KEYS: &[(&str, &str)] = &[
     ("Home / End", "first / last"),
     ("Enter", "edit QSO"),
     ("d", "delete QSO (y/n to confirm)"),
-    ("q / Esc", "back"),
+    ("Esc", "back"),
     ("F1", "help"),
 ];
 
-static EXPORT_KEYS: &[(&str, &str)] = &[
-    ("Enter", "export to ADIF"),
-    ("q / Esc", "back"),
-    ("F1", "help"),
-];
+static EXPORT_KEYS: &[(&str, &str)] =
+    &[("Enter", "export to ADIF"), ("Esc", "back"), ("F1", "help")];
 
-static HELP_KEYS: &[(&str, &str)] = &[("↑/↓", "scroll"), ("q / Esc", "back")];
+static HELP_KEYS: &[(&str, &str)] = &[("↑/↓", "scroll"), ("Esc", "back")];
 
 /// State for the help screen.
 #[derive(Debug, Clone)]
@@ -109,7 +106,7 @@ impl HelpState {
                 self.scroll = self.scroll.saturating_add(1);
                 Action::None
             }
-            KeyCode::Char('q') | KeyCode::Esc => Action::Navigate(self.origin),
+            KeyCode::Esc => Action::Navigate(self.origin),
             _ => Action::None,
         }
     }
@@ -181,7 +178,7 @@ pub fn draw_help(state: &HelpState, frame: &mut Frame, area: Rect) {
     frame.render_widget(paragraph, content_area);
 
     let footer =
-        Paragraph::new("↑/↓: scroll  q/Esc: back").style(Style::default().fg(Color::DarkGray));
+        Paragraph::new("↑/↓: scroll  Esc: back").style(Style::default().fg(Color::DarkGray));
     frame.render_widget(footer, footer_area);
 }
 
@@ -270,10 +267,10 @@ mod tests {
         }
 
         #[test]
-        fn q_navigates_to_log_select() {
+        fn q_is_ignored() {
             let mut state = HelpState::new();
             let action = state.handle_key(press(KeyCode::Char('q')));
-            assert_eq!(action, Action::Navigate(Screen::LogSelect));
+            assert_eq!(action, Action::None);
         }
 
         #[test]
@@ -281,14 +278,6 @@ mod tests {
             let mut state = HelpState::new();
             let action = state.handle_key(press(KeyCode::Esc));
             assert_eq!(action, Action::Navigate(Screen::LogSelect));
-        }
-
-        #[test]
-        fn q_navigates_to_origin() {
-            let mut state = HelpState::new();
-            state.set_origin(Screen::QsoEntry);
-            let action = state.handle_key(press(KeyCode::Char('q')));
-            assert_eq!(action, Action::Navigate(Screen::QsoEntry));
         }
 
         #[test]
@@ -483,10 +472,9 @@ mod tests {
         }
 
         #[test]
-        fn footer_contains_q_and_esc() {
+        fn footer_contains_esc() {
             let state = HelpState::new();
             let output = render_help(&state, 80, 30);
-            assert!(output.contains('q'), "footer should mention q");
             assert!(output.contains("Esc"), "footer should mention Esc");
         }
     }

--- a/src/tui/screens/log_select.rs
+++ b/src/tui/screens/log_select.rs
@@ -74,7 +74,7 @@ impl LogSelectState {
                 KeyCode::Enter => self.select_current(),
                 KeyCode::Char('n') => Action::Navigate(Screen::LogCreate),
                 KeyCode::Char('d') => self.start_delete(),
-                KeyCode::Char('q') | KeyCode::Esc => Action::Quit,
+                KeyCode::Esc => Action::Quit,
                 _ => Action::None,
             },
         }
@@ -218,7 +218,7 @@ pub fn draw_log_select(state: &LogSelectState, frame: &mut Frame, area: Rect) {
 
     frame.render_widget(table, table_area);
 
-    let footer = Paragraph::new("n: new  Enter: open  d: delete  q: quit  F1: help")
+    let footer = Paragraph::new("n: new  Enter: open  d: delete  Esc: quit  F1: help")
         .style(Style::default().fg(Color::DarkGray));
     frame.render_widget(footer, footer_area);
 
@@ -413,9 +413,9 @@ mod tests {
         use super::*;
 
         #[test]
-        fn q_quits() {
+        fn q_is_ignored() {
             let mut state = make_populated_state();
-            assert_eq!(state.handle_key(press(KeyCode::Char('q'))), Action::Quit);
+            assert_eq!(state.handle_key(press(KeyCode::Char('q'))), Action::None);
         }
 
         #[test]

--- a/src/tui/screens/qso_list.rs
+++ b/src/tui/screens/qso_list.rs
@@ -82,7 +82,7 @@ impl QsoListState {
                     }
                     Action::None
                 }
-                KeyCode::Esc | KeyCode::Char('q') => Action::Navigate(Screen::QsoEntry),
+                KeyCode::Esc => Action::Navigate(Screen::QsoEntry),
                 _ => Action::None,
             },
         }
@@ -222,7 +222,7 @@ pub fn draw_qso_list(state: &QsoListState, log: Option<&Log>, frame: &mut Frame,
         frame.render_widget(err_line, footer_area);
     } else {
         let footer =
-            Paragraph::new("↑↓: navigate  Home/End: jump  Enter: edit  d: delete  q: back")
+            Paragraph::new("↑↓: navigate  Home/End: jump  Enter: edit  d: delete  Esc: back")
                 .style(Style::default().fg(Color::DarkGray));
         frame.render_widget(footer, footer_area);
     }
@@ -397,10 +397,10 @@ mod tests {
         }
 
         #[test]
-        fn q_navigates_to_qso_entry() {
+        fn q_is_ignored() {
             let mut state = QsoListState::new();
             let action = state.handle_key(press(KeyCode::Char('q')), 5);
-            assert_eq!(action, Action::Navigate(Screen::QsoEntry));
+            assert_eq!(action, Action::None);
         }
     }
 
@@ -639,7 +639,7 @@ mod tests {
             let output = render_qso_list(&state, None, 80, 20);
             assert!(output.contains("navigate"), "should show navigation hint");
             assert!(output.contains("Enter: edit"), "should show edit hint");
-            assert!(output.contains("q: back"), "should show back hint");
+            assert!(output.contains("Esc: back"), "should show back hint");
             assert!(output.contains("Home/End"), "should show jump hint");
         }
 


### PR DESCRIPTION
## Summary

- Removes `q` from all navigation/quit match arms in `log_select`, `qso_list`, and `help` screens — `Esc` is now the sole key for navigating back or quitting
- Updates footer hint strings and static key tables in `help.rs` to reflect the change
- Updates `docs/user-guide.md` keybinding tables and prose; also fixes a stale "Park" → "Type" column name in the Log Select description
- Moves Phase 5.4 to completed in `docs/roadmap.md`
- Renames `q_quits`/`q_navigates_*` tests to `q_is_ignored` asserting `Action::None`; updates all affected integration tests in `app.rs`

## Test plan

- [x] `make ci` passes — 712 tests, 0 failures, coverage threshold met
- [x] `esc_quits` (log_select), `esc_navigates_to_qso_entry` (qso_list), `esc_navigates_to_log_select` + `esc_navigates_to_origin` (help) all confirm Esc still works
- [x] `q_is_ignored` tests in all three screen modules confirm `q` returns `Action::None`
- [x] App-level integration tests updated: `q_on_*_is_ignored` confirm no screen transitions on `q`
- [x] Footer rendering tests updated to assert `Esc: back`/`Esc: quit` hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)